### PR TITLE
add InfluxDB token authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ Minimal config is:
 
 `host` and `database` describe the connection to InfluxDB.
 
+Optional parameter `token` can be set to an InfluxDB authentication token for use with token-based authorization.
+
 `gas` is a list of objects and describes, which group addresses should be monitored and what type the data has. The syntax is:
 
 ```json

--- a/config.cpp
+++ b/config.cpp
@@ -416,6 +416,12 @@ int parse_config(config_t *config, void (*periodic_read_fkt)(knx_timer_t *timer)
 		config->password = strdup(obj1->valuestring);
 	}
 
+	obj1 = cJSON_GetObjectItemCaseSensitive(json, "token");
+	if (obj1 && cJSON_IsString(obj1) && (obj1->valuestring != NULL))
+	{
+		config->token = strdup(obj1->valuestring);
+	}
+
 	// Sender tags
 	obj1 = cJSON_GetObjectItemCaseSensitive(json, "sender_tags");
 	// sender_tags is optional

--- a/config.h
+++ b/config.h
@@ -80,6 +80,7 @@ typedef struct __config
 	char *database;
 	char *user;
 	char *password;
+	char *token;
 	bool dryrun;
 	knxnet::address_t physaddr;
 	ga_t *gas[UINT16_MAX];

--- a/knx2influx.cpp
+++ b/knx2influx.cpp
@@ -89,6 +89,14 @@ static void post(char const *data)
 		curl_easy_setopt(handle, CURLOPT_CUSTOMREQUEST, "POST");
 		curl_easy_setopt(handle, CURLOPT_TCP_KEEPALIVE, 1L);
 		curl_easy_setopt(handle, CURLOPT_WRITEFUNCTION, curl_write_data);
+
+		if (config.token != nullptr) {
+			struct curl_slist *headers = NULL;
+			char token_header[1024] = "Authorization: Token ";
+			strcat(token_header, config.token);
+			headers = curl_slist_append(headers, token_header);
+			curl_easy_setopt(handle, CURLOPT_HTTPHEADER, headers);
+		}
 	}
 
 	curl_easy_setopt(handle, CURLOPT_POSTFIELDS, data);


### PR DESCRIPTION
This patch adds token-based authentication to knx2influx. Setting `token` in `knx2influx.json` to InfluxDB token enables authentication.